### PR TITLE
fix: resolve emoji rendering and translation interpolation issues

### DIFF
--- a/i18n/translation.ts
+++ b/i18n/translation.ts
@@ -1,6 +1,20 @@
 import { en } from './locales/en';
 
-export const t = (key: any) => {
+export const t = (key: any, params?: any) => {
 	const translation = en[key];
-	return translation;
+
+	const withEmoji = translation.replace(/:([a-z_]+):/g, (match, code) => {
+		const emojiMap: Record<string, string> = {
+			smile: '😄',
+		};
+		return emojiMap[code] || match;
+	});
+
+	if (!params) return withEmoji;
+
+	const withVars = withEmoji.replace(/\${([^}]+)}/g, (match, path) => {
+		return path.split('.').reduce((obj: any, key: string) => obj?.[key], params) ?? match;
+	});
+
+	return withVars;
 };

--- a/lib/processors/QuickPollProcessor.ts
+++ b/lib/processors/QuickPollProcessor.ts
@@ -14,13 +14,13 @@ export class QuickPollProcessor implements IProcessor {
 		const assoc = new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, uuid);
 		const [pollData] = (await read.getPersistenceReader().readByAssociation(assoc)) as IPollData[];
 		if (!pollData) {
-			console.error(t('poll_with_uuid_not_found'));
+			console.error(t('poll_with_uuid_not_found', { uuid }));
 			return;
 		}
 
 		const room = await read.getRoomReader().getById(pollData.roomId);
 		if (!room) {
-			console.error(t('poll_with_room_not_found'));
+			console.error(t('poll_with_room_not_found', { pollData }));
 			return;
 		}
 
@@ -66,7 +66,7 @@ No (${noPercentage.toFixed(2)}%): ${pollData.responses.no.join(', ')}
 		if (creator) {
 			await sendDirectMessage(read, modify, creator, detailedStatsText, persis);
 		} else {
-			console.error(t('poll_creator_with_username_not_found'));
+			console.error(t('poll_creator_with_username_not_found', { pollData }));
 		}
 
 		await persis.removeByAssociation(assoc);

--- a/modals/agile-settings/AgileModal.ts
+++ b/modals/agile-settings/AgileModal.ts
@@ -92,7 +92,7 @@ export async function AgileModal({
 			initialValue: agileMessage,
 			placeholder: {
 				text: t('agile_message_placeholder'),
-				type: TextObjectType.PLAINTEXT,
+				type: TextObjectType.MARKDOWN,
 			},
 		}),
 		blockId: 'agileMessage',


### PR DESCRIPTION
## Title
Fix emoji rendering and translation interpolation issues

Fixes #8 

## Description:
This PR addresses two issues:

- Placeholder text in the /agile-settings modal did not render the :smile: emoji visually.
- Translations with variable interpolation, such as poll_with_uuid_not_found: 'Poll with ID ${uuid} not found', were not replacing correctly.